### PR TITLE
Replace header guards in libxos with pragma once

### DIFF
--- a/libxos/include/stdtyp.h
+++ b/libxos/include/stdtyp.h
@@ -7,8 +7,7 @@
  * MIT license
  */
 
-#ifndef __STDTYP_H_LIBXOS__
-#define __STDTYP_H_LIBXOS__
+#pragma once
 
 #define NULL 0
 
@@ -25,7 +24,3 @@ typedef unsigned long long uint64_t;
 typedef signed long long int64_t;
 
 typedef uint32_t size_t;
-
-#endif
-
-

--- a/libxos/include/string.h
+++ b/libxos/include/string.h
@@ -7,13 +7,11 @@
  * MIT license
  */
 
-#ifndef __STRING_H_LIBXOS__
-#define __STRING_H_LIBXOS__
+#pragma once
 
 #include <stdtyp.h>
 
 extern size_t strlen(char *string);
 
-#endif
 
 

--- a/libxos/include/xos.h
+++ b/libxos/include/xos.h
@@ -7,8 +7,7 @@
  * MIT license
  */
 
-#ifndef __XOS_H_LIBXOS__
-#define __XOS_H_LIBXOS__
+#pragma once
 
 #include <stdtyp.h>
 
@@ -202,7 +201,7 @@ extern xos_component xos_create_canvas(xos_window window, int16_t x, int16_t y, 
 extern void xos_redraw_canvas(xos_window window, xos_canvas_t *canvas);
 extern uint32_t *xos_canvas_get_buffer(xos_window window, xos_component component);
 
-#endif
+
 
 
 


### PR DESCRIPTION
Pragma once are usually better than include guards, as they're supported by most compilers and have slightly less build time. They also look cleaner.